### PR TITLE
Refined \resumeOrganizationHeading command

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -106,11 +106,11 @@
 }
 
 
-\newcommand{\resumeOrganizationHeading}[4]{
+\newcommand{\resumeOrganizationHeading}[3]{
   \vspace{-2pt}\item
-    \begin{tabular*}{0.97\textwidth}[t]{l@{\extracolsep{\fill}}r}
+    \begin{tabular*}{0.97\textwidth}{l@{\extracolsep{\fill}}r}
       \textbf{#1} & \textit{\small #2} \\
-      \textit{\small#3}
+      \multicolumn{2}{p{0.97\textwidth}}{\textit{\small #3}} \\
     \end{tabular*}\vspace{-7pt}
 }
 


### PR DESCRIPTION
Adjusted layout of \resumeOrganizationHeading command to prevent third parameter overflow 

Reduced parameter count from 4 to 3.